### PR TITLE
fix: input checker now know about times in UTC format

### DIFF
--- a/R/Access_KlimaiNorge2100.r
+++ b/R/Access_KlimaiNorge2100.r
@@ -68,7 +68,7 @@ Access_KlimaiNorge2100 <- function(
         ),
         Time = list(
             Input = c(Start, Stop),
-            Allowed = QuickFacts_ls$time$extent,
+            Allowed = as.POSIXct(paste0(QuickFacts_ls$time$extent, "00:00:00"), tz = "UTC"),
             Operator = "exceeds"
         ),
         Methods = list(

--- a/R/Access_NORA3.r
+++ b/R/Access_NORA3.r
@@ -57,7 +57,7 @@ Access_NORA3 <- function(
     ),
     Time = list(
       Input = c(Start, Stop),
-      Allowed = c(QuickFacts_ls$time$extent[1], paste0(format(Sys.time(), "%Y-%m-%d %H"), ":00")), # assuming current day and hour as possible end since dataset is released ongoingly
+      Allowed = c(as.POSIXct(paste0(QuickFacts_ls$time$extent[1], "00:00:00"), tz = "UTC"), as.POSIXct(paste0(format(Sys.time(), "%Y-%m-%d %H"), ":00"), tz = "UTC ")), # assuming current day and hour as possible end since dataset is released ongoingly
       Operator = "exceeds"
     ),
     leadTimeHour = list(

--- a/R/Access_reanalysis_cerra_single_levels.r
+++ b/R/Access_reanalysis_cerra_single_levels.r
@@ -133,7 +133,7 @@ Access_reanalysis_cerra_single_levels <- function(
         Time = list(
             Input = Dates_df$UTC,
             Allowed = c(
-                QuickFacts_ls$time$extent[1],
+                as.POSIXct(paste0(QuickFacts_ls$time$extent[1], "00:00:00"), tz = "UTC"),
                 gsub(" UTC", "", Helper_MakeUTC(dates = as.POSIXct(paste0(format(Sys.time(), "%Y-%m-%d %H"), ":00")))$UTC) # assuming current day and hour as possible end since dataset is released ongoingly
             ),
             Operator = "exceeds"

--- a/R/Helper_InputChecker.r
+++ b/R/Helper_InputChecker.r
@@ -10,13 +10,13 @@
 #'
 #' @examples
 #' Variable <- "Maximum Air Temperature"
-#' DateStart <- "1971-01-01"
-#' DateStop <- "1971-08-31"
+#' dateStart <- "1971-01-01"
+#' dateStop <- "1971-08-31"
 #' Model <- "CNRM_CCLM"
 #' Scenario <- "rcp85"
 #'
-#' Start <- as.POSIXct(paste0(DateStart, "00:00:00"), tz = "UTC")
-#' Stop <- as.POSIXct(paste0(DateStop, "00:00:00"), tz = "UTC")
+#' Start <- as.POSIXct(paste0(dateStart, "00:00:00"), tz = "UTC")
+#' Stop <- as.POSIXct(paste0(dateStop, "00:00:00"), tz = "UTC")
 #'
 #' inputCheck <- list(
 #'     Variable = list(

--- a/man/Helper_InputChecker.Rd
+++ b/man/Helper_InputChecker.Rd
@@ -18,13 +18,13 @@ Loops over contents of a named list of lists where each sublist contains the poi
 }
 \examples{
 Variable <- "Maximum Air Temperature"
-DateStart <- "1971-01-01"
-DateStop <- "1971-08-31"
+dateStart <- "1971-01-01"
+dateStop <- "1971-08-31"
 Model <- "CNRM_CCLM"
 Scenario <- "rcp85"
 
-Start <- as.POSIXct(paste0(DateStart, "00:00:00"), tz = "UTC")
-Stop <- as.POSIXct(paste0(DateStop, "00:00:00"), tz = "UTC")
+Start <- as.POSIXct(paste0(dateStart, "00:00:00"), tz = "UTC")
+Stop <- as.POSIXct(paste0(dateStop, "00:00:00"), tz = "UTC")
 
 inputCheck <- list(
     Variable = list(


### PR DESCRIPTION
Resolving an issue where input checker denied upper bound of time extent when queried